### PR TITLE
fix README translation of zh

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository aims at collaboratively translating our [Machine Learning cheatsheets](https://github.com/afshinea/stanford-cs-229-machine-learning) into a ton of languages, so that this content can be enjoyed by anyone from any part of the world!
 
 ## Progression
-|Cheatsheet topic|[Deutsch](https://github.com/shervinea/cheatsheet-translation/tree/master/de)|[Español](https://github.com/shervinea/cheatsheet-translation/tree/master/es)|[فارسی](https://github.com/shervinea/cheatsheet-translation/tree/master/fa)|[Français](https://github.com/shervinea/cheatsheet-translation/tree/master/fr)|[日本語](https://github.com/shervinea/cheatsheet-translation/tree/master/ja)|[Português](https://github.com/shervinea/cheatsheet-translation/tree/master/pt)|[官话](https://github.com/shervinea/cheatsheet-translation/tree/master/zh)|
+|Cheatsheet topic|[Deutsch](https://github.com/shervinea/cheatsheet-translation/tree/master/de)|[Español](https://github.com/shervinea/cheatsheet-translation/tree/master/es)|[فارسی](https://github.com/shervinea/cheatsheet-translation/tree/master/fa)|[Français](https://github.com/shervinea/cheatsheet-translation/tree/master/fr)|[日本語](https://github.com/shervinea/cheatsheet-translation/tree/master/ja)|[Português](https://github.com/shervinea/cheatsheet-translation/tree/master/pt)|[简体中文](https://github.com/shervinea/cheatsheet-translation/tree/master/zh)|
 |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 |Deep learning|0%|0%|0%|**100%**|0%|0%|0%|
 |Supervised learning|0%|0%|0%|0%|0%|0%|1%|


### PR DESCRIPTION
zh means [Chinese language](https://en.wikipedia.org/wiki/ZH). Mandarin Chinese is being compared with Cantonese, which emphasizes the dialect side of the language. Simplified Chinese would be better in translation.