### PR TITLE
Revised an unnecessary space and separators.

### DIFF
--- a/ja/cs-230-convolutional-neural-networks.md
+++ b/ja/cs-230-convolutional-neural-networks.md
@@ -649,7 +649,7 @@
 
 **93. [Training set, Noise, Real-world image, Generator, Discriminator, Real Fake]**
 
-&#10230; [学習セット, ノイズ, 現実世界の画像, 生成器, 識別器, 真 偽]
+&#10230; [学習セット, ノイズ, 現実世界の画像, 生成器, 識別器, 真偽]
 
 <br>
 
@@ -698,7 +698,7 @@
 
 **100. Reviewed by X, Y and Z**
 
-&#10230; X, Y, Z 校正
+&#10230; X・Y・Z 校正
 
 <br>
 


### PR DESCRIPTION
真偽 doesn't need a space between 真 and 偽.
Other cases of names are separated with '・', but a case is ','